### PR TITLE
Feature/system update

### DIFF
--- a/src/catharsys/setup/cmd/install_system.py
+++ b/src/catharsys/setup/cmd/install_system.py
@@ -29,11 +29,11 @@ g_sCmdDesc = "Installs the Catharsys modules"
 
 ####################################################################
 def AddArgParseArguments(_xArgParser):
-
     _xArgParser.add_argument("--force-dist", dest="force_dist", action="store_true", default=False)
     _xArgParser.add_argument("--force", dest="force_install", action="store_true", default=False)
     _xArgParser.add_argument("--vscode-addons", dest="vscode_addons_only", action="store_true", default=False)
     _xArgParser.add_argument("--sdist", dest="sdist", action="store_true", default=False)
+    _xArgParser.add_argument("--update", dest="update", action="store_true", default=False)
     _xArgParser.add_argument("--docs", dest="docs", nargs="*", default=None)
     _xArgParser.add_argument("--repos", dest="repos", nargs=1, default=[None])
 
@@ -55,6 +55,7 @@ def RunCmd(_argsCmd, _lArgs):
         bSourceDist=argsSubCmd.sdist,
         lDocFiles=argsSubCmd.docs,
         sReposFile=argsSubCmd.repos[0],
+        bUpdate=argsSubCmd.update,
     )
 
 

--- a/src/catharsys/setup/cmd/install_system_impl.py
+++ b/src/catharsys/setup/cmd/install_system_impl.py
@@ -216,20 +216,20 @@ def Run(
             if not isinstance(pathRepos, Path):
                 raise RuntimeError("Update can only be used on a develop install")
             # endif
-            pathMain = pathRepos.parent
+            # pathMain = pathRepos.parent
 
             # pull "image-render-setup" and install it in current environment
             repos.PullMain()
-            sEnvName = conda.GetActiveEnvName()
-            lCmds = conda.GetShellActivateCommands(sEnvName, bTestActivation=False)
-            lCmds.append("python -m pip install --editable .")
-            shell.ExecPlatformCmds(
-                lCmds=lCmds,
-                sCwd=pathMain.as_posix(),
-                bDoPrint=True,
-                bDoPrintOnError=True,
-                sPrintPrefix=">> ",
-            )
+            # sEnvName = conda.GetActiveEnvName()
+            # lCmds = conda.GetShellActivateCommands(sEnvName, bTestActivation=False)
+            # lCmds.append("python -m pip install --editable .")
+            # shell.ExecPlatformCmds(
+            #     lCmds=lCmds,
+            #     sCwd=pathMain.as_posix(),
+            #     bDoPrint=True,
+            #     bDoPrintOnError=True,
+            #     sPrintPrefix=">> ",
+            # )
         # endif
 
         if isinstance(pathRepos, Path):
@@ -242,7 +242,7 @@ def Run(
                     # endif
                 # endif
             # endfor
-            if len(lRepoPaths) == 0:
+            if len(lRepoPaths) == 0 or bUpdate is True:
                 if sReposFile is None:
                     pathRepoListFile = pathRepos / "repos-main.yaml"
                 else:
@@ -293,6 +293,16 @@ def Run(
 
     if bDocsOnly is False:
         InstallVsCodeModules(bForceInstall=bForceInstall)
+    # endif
+
+    if bUpdate is True:
+        pathRepos = util.TryGetReposPath()
+        pathMain = pathRepos.parent
+        print("******\n")
+        print(
+            f"    Run the command 'python -m pip install --editable .' in the following folder to update 'image-render-setup':\n    >> '{(pathMain.as_posix())}\n"
+        )
+        print("******\n")
     # endif
 
 

--- a/src/catharsys/setup/cmd/install_system_impl.py
+++ b/src/catharsys/setup/cmd/install_system_impl.py
@@ -39,7 +39,7 @@ from pathlib import Path
 import catharsys.setup
 
 from shutil import unpack_archive
-from catharsys.setup import util, shell, repos
+from catharsys.setup import util, shell, repos, conda
 
 g_sCmdDesc = "Installs the Catharsys modules"
 
@@ -202,15 +202,36 @@ def Run(
     bVsCodeAddOnsOnly: bool,
     lDocFiles: bool,
     sReposFile: str,
+    bUpdate: bool,
 ):
     from catharsys.setup import module
 
-    sSystem: str = platform.system()
+    # sSystem: str = platform.system()
 
     bDocsOnly = isinstance(lDocFiles, list)
 
     if bVsCodeAddOnsOnly is False and bDocsOnly is False:
         pathRepos = util.TryGetReposPath()
+        if bUpdate is True:
+            if not isinstance(pathRepos, Path):
+                raise RuntimeError("Update can only be used on a develop install")
+            # endif
+            pathMain = pathRepos.parent
+
+            # pull "image-render-setup" and install it in current environment
+            repos.PullMain()
+            sEnvName = conda.GetActiveEnvName()
+            lCmds = conda.GetShellActivateCommands(sEnvName, bTestActivation=False)
+            lCmds.append("python -m pip install --editable .")
+            shell.ExecPlatformCmds(
+                lCmds=lCmds,
+                sCwd=pathMain.as_posix(),
+                bDoPrint=True,
+                bDoPrintOnError=True,
+                sPrintPrefix=">> ",
+            )
+        # endif
+
         if isinstance(pathRepos, Path):
             lRepoPaths = []
             for pathX in pathRepos.iterdir():
@@ -232,7 +253,9 @@ def Run(
                 # endif
                 if pathRepoListFile.exists():
                     print("Cloning repositories...")
-                    repos.CloneFromRepoListFile(_pathRepoList=pathRepoListFile, _pathRepos=pathRepos)
+                    repos.CloneFromRepoListFile(
+                        _pathRepoList=pathRepoListFile, _pathRepos=pathRepos, _bPullIfExists=bUpdate
+                    )
                     # if sSystem == "Windows":
                     #     sCmd = f"Get-Content {pathRepoListFile} | vcs import"
                     # else:

--- a/src/catharsys/setup/cmd/repos_update_impl.py
+++ b/src/catharsys/setup/cmd/repos_update_impl.py
@@ -54,7 +54,13 @@ def Run():
     # sBranchDev = "main"
 
     repos.PullMain()
-    repos.PullRepoCln()
+
+    pathRepoListFile = pathRepos / "repos-main.yaml"
+    if pathRepoListFile.exists():
+        repos.CloneFromRepoListFile(_pathRepoList=pathRepoListFile, _pathRepos=pathRepos, _bPullIfExists=True)
+    else:
+        repos.PullRepoCln()
+    # endif
 
 
 # enddef


### PR DESCRIPTION
Fixes problems with installing system, introduced in previous version.
Also improves on updating system. For a develop install this can now be done via:

Pull latest version of 'image-render-setup' and either clone all repos in 'repos-main.yaml' or pull those that are already present.
`cathy repos update`

In the 'image-render-setup' folder update the main module:
`python -m pip install -e .`

Install all repos again, in case some new entry points were defined or others changed:
`cathy install system`
